### PR TITLE
Encoder

### DIFF
--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -7,4 +7,10 @@ class EnigmaEncoder
   def offset(date)
     (date.to_i**2).to_s[-4..-1].split('')
   end
+
+  def shift(keys, offset)
+    keys.map.with_index do |key, index|
+      key.to_i + offset[index].to_i
+    end
+  end
 end

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -18,7 +18,7 @@ class EnigmaEncoder
     end
   end
 
-  def caesar_cipher_shift(character, shift)
+  def caesar_shift(character, shift)
     index = @whitelist.index(character.downcase)
     index ? @whitelist.rotate(shift)[index] : character
   end
@@ -32,7 +32,7 @@ class EnigmaEncoder
     enigma_shifts = shifts(keys(key), offset(date)).rotate(-1)
     encryption = message.split('').map do |character|
       enigma_shifts = enigma_shifts.rotate
-      caesar_cipher_shift(character, enigma_shifts[0])
+      caesar_shift(character, enigma_shifts[0])
     end.join
     encryption_info(encryption, key, date)
   end

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -13,9 +13,7 @@ class EnigmaEncoder
   end
 
   def shifts(keys, offset)
-    keys.map.with_index do |key, index|
-      key.to_i + offset[index].to_i
-    end
+    keys.zip(offset).map {|key, off| key.to_i + off.to_i }
   end
 
   def caesar_shift(character, shift)

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -1,5 +1,9 @@
 class EnigmaEncoder
 
+  def initialize
+    @whitelist = ('a'..'z').to_a << ' '
+  end
+
   def keys(key)
     key.split('').each_cons(2).map {|a,b| a + b}
   end
@@ -8,9 +12,14 @@ class EnigmaEncoder
     (date.to_i**2).to_s[-4..-1].split('')
   end
 
-  def shift(keys, offset)
+  def shifts(keys, offset)
     keys.map.with_index do |key, index|
       key.to_i + offset[index].to_i
     end
+  end
+
+  def caesar_cipher_shift(character, shift)
+    index = @whitelist.index(character.downcase)
+    index ? @whitelist.rotate(shift)[index] : character
   end
 end

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -22,4 +22,10 @@ class EnigmaEncoder
     index = @whitelist.index(character.downcase)
     index ? @whitelist.rotate(shift)[index] : character
   end
+
+  def encryption_info(encryption, key, date)
+    {encryption: encryption, key: key, date: date}
+  end
+
+
 end

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -27,5 +27,13 @@ class EnigmaEncoder
     {encryption: encryption, key: key, date: date}
   end
 
-
+  #possible to-do: make a "run_message_through_caesar_shifts" super method
+  def encrypt(message, key = nil, date = nil)
+    enigma_shifts = shifts(keys(key), offset(date)).rotate(-1)
+    encryption = message.split('').map do |character|
+      enigma_shifts = enigma_shifts.rotate
+      caesar_cipher_shift(character, enigma_shifts[0])
+    end.join
+    encryption_info(encryption, key, date)
+  end
 end

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -1,3 +1,6 @@
 class EnigmaEncoder
 
+  def keys(key)
+    key.split('').each_cons(2).map {|a,b| a + b}.join
+  end
 end

--- a/lib/enigma_encoder.rb
+++ b/lib/enigma_encoder.rb
@@ -1,6 +1,10 @@
 class EnigmaEncoder
 
   def keys(key)
-    key.split('').each_cons(2).map {|a,b| a + b}.join
+    key.split('').each_cons(2).map {|a,b| a + b}
+  end
+
+  def offset(date)
+    (date.to_i**2).to_s[-4..-1].split('')
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -44,4 +44,13 @@ class EnigmaEncoderTest < Minitest::Test
     }
     assert_equal expected, @encoder.encryption_info("ai", "02715", "040895")
   end
+
+  def test_it_can_encrypt
+    expected = {
+      encryption: "keder ohulw",
+      key: "02715",
+      date: "040895"
+    }
+    assert_equal expected, @encoder.encrypt("hello world", "02715", "040895")
+  end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -45,6 +45,7 @@ class EnigmaEncoderTest < Minitest::Test
     assert_equal expected, @encoder.encryption_info("ai", "02715", "040895")
   end
 
+  #to-do: implement handling no date/key
   def test_it_can_encrypt
     expected = {
       encryption: "keder ohulw",

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -32,8 +32,9 @@ class EnigmaEncoderTest < Minitest::Test
     assert_equal " ", @encoder.caesar_shift("a", -1)
     assert_equal "q", @encoder.caesar_shift("Q", 54)
     assert_equal ",", @encoder.caesar_shift(",", 3)
-    assert_equal "!", @encoder.caesar_shift("!", 7)
-    assert_equal "?", @encoder.caesar_shift("?", 800)
+    assert_equal "!", @encoder.caesar_shift("!", -7)
+    assert_equal "d", @encoder.caesar_shift("z", 815)
+    assert_equal "g", @encoder.caesar_shift("g", 0)
   end
 
   def test_it_can_return_encryption_info

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -22,7 +22,7 @@ class EnigmaEncoderTest < Minitest::Test
   def test_it_can_set_shift
     keys = @encoder.keys("02715")
     offset = @encoder.offset("040895")
-    
-    assert_equal [2, 27, 73, 20], @encoder.shift(keys, offset)
+
+    assert_equal [3, 27, 73, 20], @encoder.shift(keys, offset)
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -19,8 +19,8 @@ class EnigmaEncoderTest < Minitest::Test
     assert_equal "1025", @encoder.offset("040895")
   end
 
-  def test_it_can_make_key_hash
-    assert_equal ({a: '1', b: '2', c: '3', d: '4'}), @encoder.key_hash("1234")
-    assert_equal ({a: '15', b: '26', c: '37', d: '48'}), @encoder.key_hash("15263748")
+  def test_it_can_make_key_array
+    assert_equal ['1', '2', '3', '4'], @encoder.key_array("1234")
+    assert_equal ['15', '26', '37', '48'], @encoder.key_array("15263748")
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -19,10 +19,17 @@ class EnigmaEncoderTest < Minitest::Test
     assert_equal ["1", "0", "2", "5"], @encoder.offset("040895")
   end
 
-  def test_it_can_set_shift
+  def test_it_can_set_shifts
     keys = @encoder.keys("02715")
     offset = @encoder.offset("040895")
 
-    assert_equal [3, 27, 73, 20], @encoder.shift(keys, offset)
+    assert_equal [3, 27, 73, 20], @encoder.shifts(keys, offset)
+  end
+
+  def test_it_can_caesar_cipher_shift
+    assert_equal "b", @encoder.caesar_cipher_shift("a", 1)
+    assert_equal "d", @encoder.caesar_cipher_shift("D", 3)
+    assert_equal " ", @encoder.caesar_cipher_shift("a", -1)
+    assert_equal "a", @encoder.caesar_cipher_shift("a", 54)
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -18,4 +18,11 @@ class EnigmaEncoderTest < Minitest::Test
   def test_it_can_set_offset
     assert_equal ["1", "0", "2", "5"], @encoder.offset("040895")
   end
+
+  def test_it_can_set_shift
+    keys = @encoder.keys("02715")
+    offset = @encoder.offset("040895")
+    
+    assert_equal [2, 27, 73, 20], @encoder.shift(keys, offset)
+  end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -14,4 +14,8 @@ class EnigmaEncoderTest < Minitest::Test
   def test_it_can_set_keys
     assert_equal "02277115", @encoder.keys("02715")
   end
+
+  def test_it_can_set_offset
+    assert_equal "1025", @encoder.offset("040895")
+  end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -35,4 +35,13 @@ class EnigmaEncoderTest < Minitest::Test
     assert_equal "!", @encoder.caesar_cipher_shift("!", 7)
     assert_equal "?", @encoder.caesar_cipher_shift("?", 800)
   end
+
+  def test_it_can_return_encryption_info
+    expected = {
+      encryption: "ai",
+      key: "02715",
+      date: "040895"
+    }
+    assert_equal expected, @encoder.encryption_info("ai", "02715", "040895")
+  end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -2,10 +2,16 @@ require_relative "test_helper"
 require "./lib/enigma_encoder"
 
 class EnigmaEncoderTest < Minitest::Test
-  
-  def test_it_exists
-    encoder = EnigmaEncoder.new
 
-    assert_instance_of EnigmaEncoder, encoder
+  def setup
+    @encoder = EnigmaEncoder.new
+  end
+
+  def test_it_exists
+    assert_instance_of EnigmaEncoder, @encoder
+  end
+
+  def test_it_can_set_keys
+    assert_equal "02277115", @encoder.keys("02715")
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -26,14 +26,14 @@ class EnigmaEncoderTest < Minitest::Test
     assert_equal [3, 27, 73, 20], @encoder.shifts(keys, offset)
   end
 
-  def test_it_can_caesar_cipher_shift
-    assert_equal "m", @encoder.caesar_cipher_shift("l", 1)
-    assert_equal "b", @encoder.caesar_cipher_shift("Z", 3)
-    assert_equal " ", @encoder.caesar_cipher_shift("a", -1)
-    assert_equal "q", @encoder.caesar_cipher_shift("Q", 54)
-    assert_equal ",", @encoder.caesar_cipher_shift(",", 3)
-    assert_equal "!", @encoder.caesar_cipher_shift("!", 7)
-    assert_equal "?", @encoder.caesar_cipher_shift("?", 800)
+  def test_it_can_caesar_shift
+    assert_equal "m", @encoder.caesar_shift("l", 1)
+    assert_equal "b", @encoder.caesar_shift("Z", 3)
+    assert_equal " ", @encoder.caesar_shift("a", -1)
+    assert_equal "q", @encoder.caesar_shift("Q", 54)
+    assert_equal ",", @encoder.caesar_shift(",", 3)
+    assert_equal "!", @encoder.caesar_shift("!", 7)
+    assert_equal "?", @encoder.caesar_shift("?", 800)
   end
 
   def test_it_can_return_encryption_info

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -18,4 +18,9 @@ class EnigmaEncoderTest < Minitest::Test
   def test_it_can_set_offset
     assert_equal "1025", @encoder.offset("040895")
   end
+
+  def test_it_can_make_key_hash
+    assert_equal ({a:1, b:2, c:3, d:4}), @encoder.key_hash("1234")
+    assert_equal ({a:15, b:26, c:37, d:48}), @encoder.key_hash("15263748")
+  end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -12,15 +12,10 @@ class EnigmaEncoderTest < Minitest::Test
   end
 
   def test_it_can_set_keys
-    assert_equal "02277115", @encoder.keys("02715")
+    assert_equal ["02", "27", "71", "15"], @encoder.keys("02715")
   end
 
   def test_it_can_set_offset
-    assert_equal "1025", @encoder.offset("040895")
-  end
-
-  def test_it_can_make_key_array
-    assert_equal ['1', '2', '3', '4'], @encoder.key_array("1234")
-    assert_equal ['15', '26', '37', '48'], @encoder.key_array("15263748")
+    assert_equal ["1", "0", "2", "5"], @encoder.offset("040895")
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -20,7 +20,7 @@ class EnigmaEncoderTest < Minitest::Test
   end
 
   def test_it_can_make_key_hash
-    assert_equal ({a:1, b:2, c:3, d:4}), @encoder.key_hash("1234")
-    assert_equal ({a:15, b:26, c:37, d:48}), @encoder.key_hash("15263748")
+    assert_equal ({a: '1', b: '2', c: '3', d: '4'}), @encoder.key_hash("1234")
+    assert_equal ({a: '15', b: '26', c: '37', d: '48'}), @encoder.key_hash("15263748")
   end
 end

--- a/test/enigma_encoder_test.rb
+++ b/test/enigma_encoder_test.rb
@@ -27,9 +27,12 @@ class EnigmaEncoderTest < Minitest::Test
   end
 
   def test_it_can_caesar_cipher_shift
-    assert_equal "b", @encoder.caesar_cipher_shift("a", 1)
-    assert_equal "d", @encoder.caesar_cipher_shift("D", 3)
+    assert_equal "m", @encoder.caesar_cipher_shift("l", 1)
+    assert_equal "b", @encoder.caesar_cipher_shift("Z", 3)
     assert_equal " ", @encoder.caesar_cipher_shift("a", -1)
-    assert_equal "a", @encoder.caesar_cipher_shift("a", 54)
+    assert_equal "q", @encoder.caesar_cipher_shift("Q", 54)
+    assert_equal ",", @encoder.caesar_cipher_shift(",", 3)
+    assert_equal "!", @encoder.caesar_cipher_shift("!", 7)
+    assert_equal "?", @encoder.caesar_cipher_shift("?", 800)
   end
 end


### PR DESCRIPTION
#### Adds `EnigmaEncoder` (name to be changed simply to Encoder later)
  - `keys`, `offset`: data used to determine shifts; return array of four strings
  - `shifts`: data passed to caesar_shift; returns array of four integers
  - `caesar_shift`: shifts a single character
  - `encryption_info`: packages info into a hash
  - `encrypt`: encrypts entire message; returns encryption_info hash

  Currently planning to refactor all of this implementation into a super class.